### PR TITLE
Add commit-ish to emulsify-gulp requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Project template for Drupal 8 themes",
   "version": "1.0.0",
   "devDependencies": {
-    "emulsify-gulp": "fourkitchens/emulsify-gulp",
+    "emulsify-gulp": "fourkitchens/emulsify-gulp#1.0.2",
     "gulp": "^3.9.1"
   },
   "scripts": {


### PR DESCRIPTION
Npm/Yarn pull from `master` by default, except development appears to be on `develop` and pinning to a specific version is an even better idea.

Fixes https://github.com/fourkitchens/emulsify-gulp/issues/29